### PR TITLE
Fix compiler warnings and errors for clean build

### DIFF
--- a/profiler.ml
+++ b/profiler.ml
@@ -1,13 +1,8 @@
-open Printf
 open Common
 
 external unpause_and_start_profiling :
   int -> Unix.file_descr -> (sample -> unit) -> unit
   = "ml_unpause_and_start_profiling"
-
-exception ExpectedSome
-
-let unwrap = function None -> raise ExpectedSome () | Some x -> x
 
 let agg_hash = Hashtbl.create 1000
 
@@ -103,36 +98,6 @@ module IntMap = Map.Make (struct
   let compare = Stdlib.compare
 end)
 
-let slash_regex = Str.regexp "[/\\.]"
-
-let add_to_line_list src_line counts l =
-  match l with
-  | None ->
-      Some [(src_line, counts)]
-  | Some v ->
-      Some ((src_line, counts) :: v)
-
-let group_by_source_file src_line counts m =
-  match src_line.filename with
-  | None ->
-      m
-  | Some f ->
-      StringMap.update f
-        (function
-          | None ->
-              Some (IntMap.add src_line.line [(src_line, counts)] IntMap.empty)
-          | Some l ->
-              Some
-                (IntMap.update src_line.line
-                   (add_to_line_list src_line counts)
-                   l) )
-        m
-
-let map_some f l =
-  List.map
-    (fun x -> f (unwrap x))
-    (List.filter (function None -> false | Some _ -> true) l)
-
 let source_line_counts_to_json (filename, function_name) (counts, lc) =
   `Assoc
     [ ("filename", `String filename)
@@ -181,28 +146,19 @@ let group_by_fold (f : 'a -> 'b) (l : 'a list) (f2 : 'b -> 'a list -> 'c) :
 let write_profiling_result output_name (agg_result : aggregate_result) =
   (* first write out the json representation of results *)
   let total_samples =
-    Hashtbl.fold (fun a b c -> c + b.self_time) agg_result 0
+    Hashtbl.fold (fun _ b c -> c + b.self_time) agg_result 0
   in
   let key_values = flatten agg_result in
-  let only_present_filenames =
-    List.filter
-      (function
-        | {filename= None}, _ ->
-            false
-        | {filename= Some x}, _ ->
-            Sys.file_exists x )
-      key_values
-  in
   (* calculate hotspots *)
   let grouped_by_file_function =
     group_by
-      (fun (k, v) ->
+      (fun (k, _) ->
         (get_or "unknown" k.filename, get_or "unknown" k.function_name) )
       key_values
   in
   let sum_counts l =
     List.fold_left
-      (fun s (k, v) ->
+      (fun s (_, v) ->
         s.self_time <- s.self_time + v.self_time ;
         s.total_time <- s.total_time + v.total_time ;
         s )
@@ -215,13 +171,13 @@ let write_profiling_result output_name (agg_result : aggregate_result) =
   let sum_counts_by_line =
     fold_groups
       (fun _ l ->
-        group_by_fold (fun (k, v) -> k.line) l (fun _ cs -> sum_counts cs) )
+        group_by_fold (fun (k, _) -> k.line) l (fun _ cs -> sum_counts cs) )
       grouped_by_file_function
   in
   let hottest_file_functions =
     take
       (List.sort
-         (fun (k0, v0) (k1, v1) -> v1.self_time - v0.self_time)
+         (fun (_, v0) (_, v1) -> v1.self_time - v0.self_time)
          (flatten sum_counts_by_file_function))
       20
   in

--- a/reports.ml
+++ b/reports.ml
@@ -23,7 +23,7 @@ let common_header name =
 |}
     name css name
 
-let common_footer = "</div></div></body></html>"
+(* let common_footer = "</div></div></body></html>" *)
 
 let shrink_file_location f =
   String.concat "/" (List.rev (take (List.rev (String.split_on_char '/' f)) 3))
@@ -140,7 +140,7 @@ let generate_stacks stack_idxs sample =
 let generate_all_stacks stack_idxs samples =
   List.flatten (List.map (generate_stacks stack_idxs) samples)
 
-let convert_sample stack_idxs sample =
+let convert_sample sample =
   `Assoc
     [ ("cpu", `Int sample.cpu)
     ; ("tid", `Int sample.thread_id)
@@ -149,8 +149,8 @@ let convert_sample stack_idxs sample =
     ; ("sf", `String (string_of_int sample.id ^ "_0"))
     ; ("weight", `Int 1) ]
 
-let stack_frames samples stack_idxs =
-  List.map (convert_sample stack_idxs) samples
+let stack_frames samples =
+  List.map (convert_sample) samples
 
 let render_trace_json output_name samples stack_idxs =
   let inverted_idxs = invert_hashtbl stack_idxs in
@@ -158,7 +158,7 @@ let render_trace_json output_name samples stack_idxs =
   let trace_json =
     `Assoc
       [ ("traceEvents", `List [])
-      ; ("samples", `List (stack_frames samples inverted_idxs))
+      ; ("samples", `List (stack_frames samples))
       ; ("stackFrames", `Assoc (generate_all_stacks inverted_idxs samples)) ]
   in
   Yojson.Basic.to_channel output_file trace_json


### PR DESCRIPTION
The following PR fixes the compiler warnings and errors when building with dune.2.6.0 to provide a clean build.